### PR TITLE
Only Download Necessary Data for CXIDB 81

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 results/
+data/*/reflection_data/

--- a/benchmarks/config/cxidb_81.sh
+++ b/benchmarks/config/cxidb_81.sh
@@ -1,5 +1,5 @@
 BENCHMARKNAME=cxidb_81
-INPUTS=(`ls $ABISMAL_BENCHMARKS/data/cxidb_81/reflection_data/figure7/*.{json,pickle}`)
+INPUTS=(`ls $ABISMAL_BENCHMARKS/data/cxidb_81/reflection_data/figure7/*.{expt,refl}`)
 
 EFFS=(
     $ABISMAL_BENCHMARKS/data/cxidb_81/reference_data/refine.eff

--- a/benchmarks/config/cxidb_81.sh
+++ b/benchmarks/config/cxidb_81.sh
@@ -1,5 +1,5 @@
 BENCHMARKNAME=cxidb_81
-INPUTS=(`ls $ABISMAL_BENCHMARKS/data/cxidb_81/reflection_data/data/figure7/by_run_t016_mr_ch/*/*/intermediates/*_reintegrated_*.{json,pickle}`)
+INPUTS=(`ls $ABISMAL_BENCHMARKS/data/cxidb_81/reflection_data/figure7/*.{json,pickle}`)
 
 EFFS=(
     $ABISMAL_BENCHMARKS/data/cxidb_81/reference_data/refine.eff

--- a/benchmarks/config/cxidb_81_small.sh
+++ b/benchmarks/config/cxidb_81_small.sh
@@ -1,7 +1,7 @@
 BENCHMARKNAME=cxidb_81_small
 INPUTS=(
-    $ABISMAL_BENCHMARKS/data/cxidb_81/reflection_data/data/figure7/by_run_t016_mr_ch/r0011/combine_experiments_t016/intermediates/t016_rg013_chunk000_reintegrated_experiments.json
-    $ABISMAL_BENCHMARKS/data/cxidb_81/reflection_data/data/figure7/by_run_t016_mr_ch/r0011/combine_experiments_t016/intermediates/t016_rg013_chunk000_reintegrated_reflections.pickle
+   $ABISMAL_BENCHMARKS/data/cxidb_81/reflection_data/figure7/r0011_t016_rg013_chunk000_reintegrated.expt  
+   $ABISMAL_BENCHMARKS/data/cxidb_81/reflection_data/figure7/r0011_t016_rg013_chunk000_reintegrated.refl
 )
 
 EFFS=(

--- a/data/cxidb_81/download.sh
+++ b/data/cxidb_81/download.sh
@@ -1,5 +1,5 @@
 mkdir -p $ABISMAL_BENCHMARKS/data/cxidb_81/reflection_data
 cd $ABISMAL_BENCHMARKS/data/cxidb_81/reflection_data
-wget https://www.cxidb.org/data/81/data.tar.gz
-tar xvf data.tar.gz
-rm data.tar.gz
+wget https://www.cxidb.org/data/81/figure7.tar.bz2
+tar xvf figure7.tar.bz2
+rm figure7.tar.bz2


### PR DESCRIPTION
CXIDB 81 had been amended with a separate file for the figure 7 integration results. This PR modifies the download script to only use these data. This saves disk space, and it removes the need to support the legacy .pickle and .json formats. 